### PR TITLE
Update and rename .github/workflows/google.yaml to .github/workflows/…

### DIFF
--- a/.github/workflows/Cloud/google.yml
+++ b/.github/workflows/Cloud/google.yml
@@ -39,14 +39,14 @@ on:
       - '"main"'
 
 env:
-  PROJECT_ID: 'my-project' # TODO: update to your Google Cloud project ID
+  PROJECT_ID: '4375461187' # TODO: update to your Google Cloud project ID
   GAR_LOCATION: 'us-central1' # TODO: update to your region
   GKE_CLUSTER: 'cluster-1' # TODO: update to your cluster name
   GKE_ZONE: 'us-central1-c' # TODO: update to your cluster zone
   DEPLOYMENT_NAME: 'gke-test' # TODO: update to your deployment name
   REPOSITORY: 'samples' # TODO: update to your Artifact Registry docker repository name
   IMAGE: 'static-site'
-  WORKLOAD_IDENTITY_PROVIDER: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider' # TODO: update to your workload identity provider
+  WORKLOAD_IDENTITY_PROVIDER: 'projects/4375461187/locations/global/workloadIdentityPools/my-pool/providers/my-provider' # TODO: update to your workload identity provider
 
 jobs:
   setup-build-publish-deploy:
@@ -114,3 +114,19 @@ jobs:
           ./kustomize build . | kubectl apply -f -
           kubectl rollout status deployment/$DEPLOYMENT_NAME
           kubectl get services -o wide
+      - name: Nitric CLI - Automated Cloud Deployment
+          # You may pin to the exact commit or the version.
+          # uses: nitrictech/actions@eb63ad6dd85ccc71e5f24bf225bd8e030ca0fff9
+      - uses: nitrictech/actions@v1.0.3
+      with:
+         # Version of the Nitric CLI to install, or "latest" (default). This accepts semver ranges like 1.33.0.
+             - version: # default is latest
+         # Token used to query nitric versions
+             - github-token: # default is ${{ github.token }}
+         # Nitric command to run, eg. up or down
+             - command: # optional
+          # Working directory containing Nitric stack
+             - working-directory: # optional
+          # Which stack you want to deploy, eg. dev
+             - stack-name: # optional
+          


### PR DESCRIPTION
…Cloud/google.yml

## Summary by Sourcery

Move and rename the existing GitHub Actions workflow for Google Cloud, update project-specific environment variables, and add a Nitric CLI deployment step to the CI process.

New Features:
- Add a Nitric CLI GitHub Action step for automated cloud deployment

Enhancements:
- Relocate and rename GitHub Actions workflow from google.yaml to Cloud/google.yml
- Update PROJECT_ID and WORKLOAD_IDENTITY_PROVIDER environment variables to use the correct Google Cloud project ID